### PR TITLE
get remote feature command fetched first 20 states only

### DIFF
--- a/src/main/java/de/is24/common/togglz/remote/command/GetRemoteFeatureStatesCommand.java
+++ b/src/main/java/de/is24/common/togglz/remote/command/GetRemoteFeatureStatesCommand.java
@@ -30,7 +30,9 @@ public class GetRemoteFeatureStatesCommand
 
   @Override
   protected Resources<Resource<RemoteFeatureState>> runCommand() throws Exception {
-    Link linkToConfigurations = getLinkByName(remoteApiUri, RemoteFeatureState.REL).expand();
+    Link linkToConfigurations = getLinkByName(remoteApiUri, RemoteFeatureState.REL).expand(
+        Collections.singletonMap("size", Integer.MAX_VALUE)
+    );
 
     ResponseEntity<Resources<Resource<RemoteFeatureState>>> responseEntity = restOperations.exchange(
       linkToConfigurations.getHref(),

--- a/src/main/java/de/is24/common/togglz/remote/command/GetRemoteFeatureStatesCommand.java
+++ b/src/main/java/de/is24/common/togglz/remote/command/GetRemoteFeatureStatesCommand.java
@@ -19,6 +19,7 @@ import java.util.Collections;
 public class GetRemoteFeatureStatesCommand
   extends AbstractFeatureStateRemoteCommand<Resources<Resource<RemoteFeatureState>>> {
   private static final Logger LOGGER = LoggerFactory.getLogger(GetRemoteFeatureStatesCommand.class);
+  public static final String PAGE_SIZE = "size";
   private final String remoteApiUri;
 
   public GetRemoteFeatureStatesCommand(HystrixConfiguration hysterixConfiguration, RestOperations restOperations,
@@ -31,7 +32,7 @@ public class GetRemoteFeatureStatesCommand
   @Override
   protected Resources<Resource<RemoteFeatureState>> runCommand() throws Exception {
     Link linkToConfigurations = getLinkByName(remoteApiUri, RemoteFeatureState.REL).expand(
-        Collections.singletonMap("size", Integer.MAX_VALUE)
+        Collections.singletonMap(PAGE_SIZE, Integer.MAX_VALUE)
     );
 
     ResponseEntity<Resources<Resource<RemoteFeatureState>>> responseEntity = restOperations.exchange(

--- a/src/main/java/de/is24/common/togglz/remote/command/GetRemoteFeatureStatesCommand.java
+++ b/src/main/java/de/is24/common/togglz/remote/command/GetRemoteFeatureStatesCommand.java
@@ -21,19 +21,31 @@ public class GetRemoteFeatureStatesCommand
   private static final Logger LOGGER = LoggerFactory.getLogger(GetRemoteFeatureStatesCommand.class);
   public static final String PAGE_SIZE = "size";
   private final String remoteApiUri;
+  private final int pageSize;
 
-  public GetRemoteFeatureStatesCommand(HystrixConfiguration hysterixConfiguration, RestOperations restOperations,
+  public GetRemoteFeatureStatesCommand(HystrixConfiguration hysterixConfiguration,
+                                       RestOperations restOperations,
                                        HateoasLinkProvider featureSwitchHateoasLinkProvider,
                                        String remoteConfigurationProviderUri) {
+    this(hysterixConfiguration, restOperations, featureSwitchHateoasLinkProvider, remoteConfigurationProviderUri,
+        1000);
+  }
+
+  public GetRemoteFeatureStatesCommand(HystrixConfiguration hysterixConfiguration,
+                                       RestOperations restOperations,
+                                       HateoasLinkProvider featureSwitchHateoasLinkProvider,
+                                       String remoteConfigurationProviderUri,
+                                       int pageSize) {
     super(hysterixConfiguration.getConfiguration(COMMAND_GROUP_KEY), restOperations, featureSwitchHateoasLinkProvider);
     this.remoteApiUri = remoteConfigurationProviderUri;
+    this.pageSize = pageSize;
   }
+
 
   @Override
   protected Resources<Resource<RemoteFeatureState>> runCommand() throws Exception {
-    Link linkToConfigurations = getLinkByName(remoteApiUri, RemoteFeatureState.REL).expand(
-        Collections.singletonMap(PAGE_SIZE, Integer.MAX_VALUE)
-    );
+    Link linkToConfigurations = getLinkByName(remoteApiUri, RemoteFeatureState.REL)
+        .expand(Collections.singletonMap(PAGE_SIZE, pageSize));
 
     ResponseEntity<Resources<Resource<RemoteFeatureState>>> responseEntity = restOperations.exchange(
       linkToConfigurations.getHref(),


### PR DESCRIPTION
Hi Guys,

Switchman-server can return list of features as Hateoas pageable resources. So the GetRemoteFeatureStatesCommand fetched only the first page, skipping the rest. Effectively at most 20 feature states were fetched from the server.

This is a hotfix. I extended the feature call by size parameter.

The fix could be better. For example it could use hateoas PageResources and iterate through the pages by wrapping each call with hystrix command.

Best regards,
Adam.